### PR TITLE
[LeetCode-47] Permutations2

### DIFF
--- a/src/main/kotlin/Permatations2.kt
+++ b/src/main/kotlin/Permatations2.kt
@@ -1,0 +1,49 @@
+fun main() {
+    val solution = Permatations2()
+    val params = intArrayOf(1, 1, 2)
+    solution.permuteUnique(params).map {
+        it.map { v ->
+            print(v)
+        }
+        println()
+    }
+}
+
+class Permatations2 {
+    lateinit var hm: HashMap<List<Int>, Int>
+    lateinit var visite: MutableList<Boolean>
+    lateinit var _n: IntArray
+    lateinit var list: MutableList<Int>
+    fun permuteUnique(nums: IntArray): List<List<Int>> {
+        _n = nums
+        visite = MutableList(nums.size) { false }
+        hm = HashMap()
+        list = MutableList(nums.size) { 0 }
+
+        dfs(0)
+
+        val result = ArrayList<List<Int>>()
+        for (k in hm.keys) {
+            result.add(k)
+        }
+        return result.toList()
+    }
+
+    fun dfs(count: Int) {
+        if (count == _n.size) {
+            if (hm[list.toList()] == null) {
+                hm[list.toList()] = 1
+            }
+            return
+        }
+
+        for (i in 0 until _n.size) {
+            if (!visite[i]) {
+                visite[i] = true
+                list[count] = _n[i]
+                dfs(count+1)
+                visite[i] = false
+            }
+        }
+    }
+}


### PR DESCRIPTION
- visite배열 이용하여 방문하지 않은 노드 방문, 모든 조합을 찾는다
- nums 배열에 중복된 원소가 있는경우 중복된 경우가 생길수 있기때문에 hash map 을 이용하여 중복방지
(set을 이용하면 더 좋았을텐데 맨날 풀고나면 생각남..)